### PR TITLE
Fix compile failure on OSX 10.9.4

### DIFF
--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -25,6 +25,7 @@
 
 #include "core/utf8/utf8.h"
 #include <time.h>
+#include <iostream>
 
 /*
 #include "formats/hg.h"


### PR DESCRIPTION
`make` failed with messages:

``` text
src/gource_settings.cpp:1634:20: error: no member named 'cin' in namespace 'std'
        while(std::cin.peek() == EOF && !std::cin.fail()) SDL_Delay(100);
              ~~~~~^
src/gource_settings.cpp:1634:47: error: no member named 'cin' in namespace 'std'
        while(std::cin.peek() == EOF && !std::cin.fail()) SDL_Delay(100);
                                         ~~~~~^
src/gource_settings.cpp:1637:14: error: no member named 'cin' in namespace 'std'
        std::cin.clear();
        ~~~~~^
1 warning and 3 errors generated.
make: *** [src/mal4s-gource_settings.o] Error 1
```
